### PR TITLE
read from ~/.vault-token if applicable

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -61,9 +61,18 @@ class LookupModule(LookupBase):
         if not url:
             raise AnsibleError('VAULT_ADDR environment variable is missing')
 
+        # the environment variable takes precedence over the file-based token
         token = os.getenv('VAULT_TOKEN')
         if not token:
-            raise AnsibleError('VAULT_TOKEN environment variable is missing')
+            try:
+                with open(os.path.join(os.getenv('HOME'), '.vault-token')) as file:
+                    token = file.read()
+            except IOError:
+                # token not found in file is same case below as not found in env var
+                pass
+        if not token:
+            raise AnsibleError('Vault authentication token missing. Specify with'
+                               ' VAULT_TOKEN environment variable or $HOME/.vault-token')
 
         cafile = os.getenv('VAULT_CACERT')
         capath = os.getenv('VAULT_CAPATH')


### PR DESCRIPTION
Only if VAULT_TOKEN is not set. If it is, the env var takes precedence.

This is the same behavior currenlty documented at
https://www.vaultproject.io/docs/commands/environment.html

Also verified empirically with the vault v0.6.1 client.